### PR TITLE
ラベルが存在しないのにremoveLabelを呼び出すとActionがエラーになる問題の修正

### DIFF
--- a/.github/workflows/pr-approved-replace-label.yml
+++ b/.github/workflows/pr-approved-replace-label.yml
@@ -19,9 +19,13 @@ jobs:
         with:
           script: |
             const UNLABEL = 'Review/QA';
-            github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: UNLABEL,
-            });
+            try {
+              github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: UNLABEL,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e
+            }

--- a/.github/workflows/pr-approved-replace-label.yml
+++ b/.github/workflows/pr-approved-replace-label.yml
@@ -16,16 +16,13 @@ jobs:
               labels: [LABEL],
             });
       - uses: actions/github-script@v6
+        if: contains(github.event.pull_request.labels.*.name, 'Review/QA')
         with:
           script: |
             const UNLABEL = 'Review/QA';
-            try {
-              github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: UNLABEL,
-              });
-            } catch (e) {
-              if (e.status !== 404) throw e
-            }
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: UNLABEL,
+            });

--- a/.github/workflows/pr-changes-requested-replace-label.yml
+++ b/.github/workflows/pr-changes-requested-replace-label.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const UNLABEL = 'Shit It';
+            const UNLABEL = 'Ship It';
             try {
               github.rest.issues.removeLabel({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-changes-requested-replace-label.yml
+++ b/.github/workflows/pr-changes-requested-replace-label.yml
@@ -16,30 +16,24 @@ jobs:
               labels: [LABEL],
             });
       - uses: actions/github-script@v6
+        if: contains(github.event.pull_request.labels.*.name, 'Review/QA')
         with:
           script: |
             const UNLABEL = 'Review/QA';
-            try {
-              github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: UNLABEL,
-              });
-            } catch (e) {
-              if (e.status !== 404) throw e
-            }
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: UNLABEL,
+            });
       - uses: actions/github-script@v6
+        if: contains(github.event.pull_request.labels.*.name, 'Ship It')
         with:
           script: |
             const UNLABEL = 'Ship It';
-            try {
-              github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: UNLABEL,
-              });
-            } catch (e) {
-              if (e.status !== 404) throw e
-            }
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: UNLABEL,
+            });

--- a/.github/workflows/pr-changes-requested-replace-label.yml
+++ b/.github/workflows/pr-changes-requested-replace-label.yml
@@ -19,9 +19,27 @@ jobs:
         with:
           script: |
             const UNLABEL = 'Review/QA';
-            github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: UNLABEL,
-            });
+            try {
+              github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: UNLABEL,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e
+            }
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const UNLABEL = 'Shit It';
+            try {
+              github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: UNLABEL,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e
+            }

--- a/.github/workflows/pr-opened-assign-owner.yml
+++ b/.github/workflows/pr-opened-assign-owner.yml
@@ -3,6 +3,7 @@ on:
 
 jobs:
   add_assignees:
+    if: github.event_name == 'pull_request' && !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/pr-review-requested-replace-label.yml
+++ b/.github/workflows/pr-review-requested-replace-label.yml
@@ -19,9 +19,13 @@ jobs:
         with:
           script: |
             const UNLABEL = 'In Progress';
-            github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: UNLABEL,
-            });
+            try {
+              github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: UNLABEL,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e
+            }

--- a/.github/workflows/pr-review-requested-replace-label.yml
+++ b/.github/workflows/pr-review-requested-replace-label.yml
@@ -16,16 +16,13 @@ jobs:
               labels: [LABEL],
             });
       - uses: actions/github-script@v6
+        if: contains(github.event.pull_request.labels.*.name, 'In Progress')
         with:
           script: |
             const UNLABEL = 'In Progress';
-            try {
-              github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: UNLABEL,
-              });
-            } catch (e) {
-              if (e.status !== 404) throw e
-            }
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: UNLABEL,
+            });


### PR DESCRIPTION
関連： https://github.com/nota/GyazoiOS/issues/133

## About

- 前提：このリポジトリのActionsは、複数のリポジトリから参照されている
- このリポジトリのActionsは、Pull requestのラベル管理を自動化しているものが多い
- 「AAAが起きた時にラベルをXからYに置き換える」というActionsがいくつかあるが、存在しないラベルを削除しようとすると、そのGitHub Actionsはエラーで失敗表示になる
- CIは通っているのにラベル管理のせいで失敗表示になるのはわかりにくいし気持ち悪いので、修正したい